### PR TITLE
Add methods for exposing collection entries as Observable<read-only-collection>

### DIFF
--- a/src/TinkState/Runtime/Internal/ObservableDictionary.cs
+++ b/src/TinkState/Runtime/Internal/ObservableDictionary.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace TinkState.Internal
 {
-	class ObservableDictionary<TKey, TValue> : Dispatcher, TinkState.ObservableDictionary<TKey, TValue>, DispatchingObservable<ObservableDictionary<TKey, TValue>>
+	partial class ObservableDictionary<TKey, TValue> : Dispatcher, TinkState.ObservableDictionary<TKey, TValue>, DispatchingObservable<ObservableDictionary<TKey, TValue>>
 	{
 		readonly Dictionary<TKey, TValue> entries;
 		bool valid;
@@ -92,6 +92,11 @@ namespace TinkState.Internal
 			((ICollection<KeyValuePair<TKey, TValue>>)entries).CopyTo(array, arrayIndex);
 		}
 
+		public Observable<IReadOnlyDictionary<TKey, TValue>> Observe()
+		{
+			return this;
+		}
+
 		public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator()
 		{
 			Calculate();
@@ -148,7 +153,7 @@ namespace TinkState.Internal
 		void Calculate()
 		{
 			valid = true;
-			AutoObservable.Track(this);
+			AutoObservable.Track<ObservableDictionary<TKey, TValue>>(this);
 		}
 
 		void Invalidate()

--- a/src/TinkState/Runtime/Internal/ObservableDictionary_ObservableOfReadOnlyDictionary.cs
+++ b/src/TinkState/Runtime/Internal/ObservableDictionary_ObservableOfReadOnlyDictionary.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace TinkState.Internal
+{
+	partial class ObservableDictionary<TKey, TValue> : Observable<IReadOnlyDictionary<TKey, TValue>>, DispatchingObservable<IReadOnlyDictionary<TKey, TValue>>
+	{
+		IReadOnlyDictionary<TKey, TValue> Observable<IReadOnlyDictionary<TKey, TValue>>.Value
+		{
+			get => AutoObservable.Track<IReadOnlyDictionary<TKey, TValue>>(this);
+		}
+
+		IDisposable Observable<IReadOnlyDictionary<TKey, TValue>>.Bind(Action<IReadOnlyDictionary<TKey, TValue>> callback, IEqualityComparer<IReadOnlyDictionary<TKey, TValue>> comparer, Scheduler scheduler)
+		{
+			return new Binding<IReadOnlyDictionary<TKey, TValue>>(this, callback, comparer, scheduler);
+		}
+
+		Observable<TOut> Observable<IReadOnlyDictionary<TKey, TValue>>.Map<TOut>(Func<IReadOnlyDictionary<TKey, TValue>, TOut> transform, IEqualityComparer<TOut> comparer)
+		{
+			return new TransformObservable<IReadOnlyDictionary<TKey, TValue>, TOut>(this, transform, comparer);
+		}
+
+		IReadOnlyDictionary<TKey, TValue> ValueProvider<IReadOnlyDictionary<TKey, TValue>>.GetCurrentValue()
+		{
+			valid = true;
+			return entries;
+		}
+
+		IEqualityComparer<IReadOnlyDictionary<TKey, TValue>> DispatchingObservable<IReadOnlyDictionary<TKey, TValue>>.GetComparer()
+		{
+			return NeverEqualityComparer<IReadOnlyDictionary<TKey, TValue>>.Instance;
+		}
+	}
+}

--- a/src/TinkState/Runtime/Internal/ObservableDictionary_ObservableOfReadOnlyDictionary.cs.meta
+++ b/src/TinkState/Runtime/Internal/ObservableDictionary_ObservableOfReadOnlyDictionary.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 029c02f218c73c64ea5933c8e5cacdd5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/src/TinkState/Runtime/Internal/ObservableList.cs
+++ b/src/TinkState/Runtime/Internal/ObservableList.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 
 namespace TinkState.Internal

--- a/src/TinkState/Runtime/Internal/ObservableList.cs
+++ b/src/TinkState/Runtime/Internal/ObservableList.cs
@@ -1,9 +1,10 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace TinkState.Internal
 {
-	class ObservableList<T> : Dispatcher, TinkState.ObservableList<T>, DispatchingObservable<ObservableList<T>>
+	partial class ObservableList<T> : Dispatcher, TinkState.ObservableList<T>, DispatchingObservable<ObservableList<T>>
 	{
 		readonly List<T> entries;
 		bool valid = false;
@@ -67,6 +68,11 @@ namespace TinkState.Internal
 			entries.CopyTo(array, arrayIndex);
 		}
 
+		public Observable<IReadOnlyList<T>> Observe()
+		{
+			return this;
+		}
+
 		public IEnumerator<T> GetEnumerator()
 		{
 			Calculate();
@@ -110,7 +116,7 @@ namespace TinkState.Internal
 		void Calculate()
 		{
 			valid = true;
-			AutoObservable.Track(this);
+			AutoObservable.Track<ObservableList<T>>(this);
 		}
 
 		void Invalidate()

--- a/src/TinkState/Runtime/Internal/ObservableList_ObservableOfReadOnlyList.cs
+++ b/src/TinkState/Runtime/Internal/ObservableList_ObservableOfReadOnlyList.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace TinkState.Internal
+{
+	partial class ObservableList<T> : Observable<IReadOnlyList<T>>, DispatchingObservable<IReadOnlyList<T>>
+	{
+		IReadOnlyList<T> Observable<IReadOnlyList<T>>.Value
+		{
+			get => AutoObservable.Track<IReadOnlyList<T>>(this);
+		}
+
+		IDisposable Observable<IReadOnlyList<T>>.Bind(Action<IReadOnlyList<T>> callback, IEqualityComparer<IReadOnlyList<T>> comparer, Scheduler scheduler)
+		{
+			return new Binding<IReadOnlyList<T>>(this, callback, comparer, scheduler);
+		}
+
+		Observable<TOut> Observable<IReadOnlyList<T>>.Map<TOut>(Func<IReadOnlyList<T>, TOut> transform, IEqualityComparer<TOut> comparer)
+		{
+			return new TransformObservable<IReadOnlyList<T>, TOut>(this, transform, comparer);
+		}
+
+		IReadOnlyList<T> ValueProvider<IReadOnlyList<T>>.GetCurrentValue()
+		{
+			valid = true;
+			return entries;
+		}
+
+		IEqualityComparer<IReadOnlyList<T>> DispatchingObservable<IReadOnlyList<T>>.GetComparer()
+		{
+			return NeverEqualityComparer<IReadOnlyList<T>>.Instance;
+		}
+	}
+}

--- a/src/TinkState/Runtime/Internal/ObservableList_ObservableOfReadOnlyList.cs.meta
+++ b/src/TinkState/Runtime/Internal/ObservableList_ObservableOfReadOnlyList.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e9349ba7416f44289eb79e980b9918db
+timeCreated: 1676367497

--- a/src/TinkState/Runtime/ObservableDictionary.cs
+++ b/src/TinkState/Runtime/ObservableDictionary.cs
@@ -13,5 +13,15 @@ namespace TinkState
 	/// <typeparam name="TValue">The type of values in the dictionary.</typeparam>
 	public interface ObservableDictionary<TKey, TValue> : IDictionary<TKey, TValue>
 	{
+		/// <summary>
+		/// Return an <see cref="Observable{T}"/> object that represent a read-only version of this dictionary.
+		/// It will trigger its bindings and tracking auto-observables every time the list is changed.
+		/// </summary>
+		/// <remarks>
+		/// The value of the returned observable is a read-only interface to the internal storage of this dictionary,
+		/// meaning that further access to its items will not be tracked by auto-observables and its contents might change over time.
+		/// </remarks>
+		/// <returns>An observable for tracking all list changes.</returns>
+		public Observable<IReadOnlyDictionary<TKey, TValue>> Observe();
 	}
 }

--- a/src/TinkState/Runtime/ObservableList.cs
+++ b/src/TinkState/Runtime/ObservableList.cs
@@ -12,5 +12,15 @@ namespace TinkState
 	/// <typeparam name="T">The type of elements in the list.</typeparam>
 	public interface ObservableList<T> : IList<T>
 	{
+		/// <summary>
+		/// Return an <see cref="Observable{T}"/> object that represent a read-only version of this list.
+		/// It will trigger its bindings and tracking auto-observables every time the list is changed.
+		/// </summary>
+		/// <remarks>
+		/// The value of the returned observable is a read-only interface to the internal storage of this list,
+		/// meaning that further access to its items will not be tracked by auto-observables and its contents might change over time.
+		/// </remarks>
+		/// <returns>An observable for tracking all list changes.</returns>
+		public Observable<IReadOnlyList<T>> Observe();
 	}
 }

--- a/src/TinkState/Tests/TestList.cs
+++ b/src/TinkState/Tests/TestList.cs
@@ -169,6 +169,11 @@ namespace Test
 
 			var mapped = observable.Map(list => string.Join(",", list));
 			Assert.That(mapped.Value, Is.EqualTo("0,1,2,3,4"));
+
+			var auto = Observable.Auto(() => string.Join(",", observable.Value));
+			Assert.That(auto.Value, Is.EqualTo("0,1,2,3,4"));
+			list.Remove(4);
+			Assert.That(auto.Value, Is.EqualTo("0,1,2,3"));
 		}
 
 		void Helper<R>(Func<R> compute, R initialExpectedValue, Action<Action<R, Action>> tests)


### PR DESCRIPTION
See #5...

 - [x] ObservableList.Observe
 - [x] ObservableDictionary.Observe

I'm going to test this in practical project a bit before merging, because there are some questions to answer, like:
 - do we want to expose the interal storage (so, not further auto-observable) or the collection itself as read-only (so auto-observable).
 - do we want a separate IReadOnlyObservableList/Dictionary interface for better code clarity?
 - (implementation detail, but still need to check) is it enough to set `valid=true` on getting the value?
