### PR TITLE
make sure the collections track themselves the same way if accessed as their read-only variants

### DIFF
--- a/src/TinkState/Runtime/Internal/ObservableDictionary_ObservableOfReadOnlyDictionary.cs
+++ b/src/TinkState/Runtime/Internal/ObservableDictionary_ObservableOfReadOnlyDictionary.cs
@@ -7,7 +7,7 @@ namespace TinkState.Internal
 	{
 		IReadOnlyDictionary<TKey, TValue> Observable<IReadOnlyDictionary<TKey, TValue>>.Value
 		{
-			get => AutoObservable.Track<IReadOnlyDictionary<TKey, TValue>>(this);
+			get => AutoObservable.Track<ObservableDictionary<TKey, TValue>>(this).entries;
 		}
 
 		IDisposable Observable<IReadOnlyDictionary<TKey, TValue>>.Bind(Action<IReadOnlyDictionary<TKey, TValue>> callback, IEqualityComparer<IReadOnlyDictionary<TKey, TValue>> comparer, Scheduler scheduler)

--- a/src/TinkState/Runtime/Internal/ObservableList_ObservableOfReadOnlyList.cs
+++ b/src/TinkState/Runtime/Internal/ObservableList_ObservableOfReadOnlyList.cs
@@ -7,7 +7,7 @@ namespace TinkState.Internal
 	{
 		IReadOnlyList<T> Observable<IReadOnlyList<T>>.Value
 		{
-			get => AutoObservable.Track<IReadOnlyList<T>>(this);
+			get => AutoObservable.Track<ObservableList<T>>(this).entries;
 		}
 
 		IDisposable Observable<IReadOnlyList<T>>.Bind(Action<IReadOnlyList<T>> callback, IEqualityComparer<IReadOnlyList<T>> comparer, Scheduler scheduler)

--- a/src/TinkState/Tests/TestDictionary.cs
+++ b/src/TinkState/Tests/TestDictionary.cs
@@ -221,6 +221,36 @@ namespace Test
 			Assert.That(auto.Value, Is.EqualTo("0-!,1-a,3-c"));
 		}
 
+		[Test]
+		public void TestObserveAndDictionaryUsedInAuto()
+		{
+			var dict = Observable.Dictionary<int, string>();
+			dict[1] = "a";
+			dict[2] = "b";
+			var dictAsObservable = dict.Observe();
+
+			List<string> Sorted(IEnumerable<string> values)
+			{
+				var list = new List<string>(values);
+				list.Sort();
+				return list;
+			}
+
+			var auto = Observable.Auto(() =>
+			{
+				var a = string.Join(',', Sorted(dict.Values.ToArray()));
+				var b = string.Join('.', Sorted(dictAsObservable.Value.Values));
+				return $"{a}-{b}";
+			});
+
+			Assert.That(auto.Value, Is.EqualTo("a,b-a.b"));
+
+			dict[1] = "A";
+			dict[2] = "B";
+			dict[3] = "C";
+			Assert.That(auto.Value, Is.EqualTo("A,B,C-A.B.C"));
+		}
+
 		void Helper<R>(Func<R> compute, R initialExpectedValue, Action<Action<R, Action>> tests)
 		{
 			var auto = Observable.Auto(compute);

--- a/src/TinkState/Tests/TestList.cs
+++ b/src/TinkState/Tests/TestList.cs
@@ -176,6 +176,30 @@ namespace Test
 			Assert.That(auto.Value, Is.EqualTo("0,1,2,3"));
 		}
 
+
+		[Test]
+		public void TestObserveAndListUsedInAuto()
+		{
+			var list = Observable.List<string>();
+			list.Add("a");
+			list.Add("b");
+			var listAsObservable = list.Observe();
+
+			var auto = Observable.Auto(() =>
+			{
+				var a = string.Join(',', list);
+				var b = string.Join('.', listAsObservable.Value);
+				return $"{a}-{b}";
+			});
+
+			Assert.That(auto.Value, Is.EqualTo("a,b-a.b"));
+
+			list[0] = "A";
+			list[1] = "B";
+			list.Add("C");
+			Assert.That(auto.Value, Is.EqualTo("A,B,C-A.B.C"));
+		}
+
 		void Helper<R>(Func<R> compute, R initialExpectedValue, Action<Action<R, Action>> tests)
 		{
 			var auto = Observable.Auto(compute);


### PR DESCRIPTION
This is the easiest fix i could come up with and it's pretty straightforward if we think about it :)

I still would like to find some time to clean up the whole AutoObservable business (not sure if it can be simplified though), but for now this will do.